### PR TITLE
(maint) Add missing gems to dev group

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -8,6 +8,7 @@ dependencies:
         - gem: metadata-json-lint
         - gem: mocha
           version: '< 1.2.0'
+        - gem: parallel_tests
         - gem: pry
         - gem: puppet-blacksmith
           version: '>= 3.4.0'
@@ -24,6 +25,8 @@ dependencies:
         - gem: rubocop
       r2.1:
       r2.3:
+        - gem: rubocop-rspec
+          version: '~> 1.6'
     system:
       shared:
         - gem: beaker-puppet_install_helper


### PR DESCRIPTION
Added:
- parallel_tests gem for all ruby versions
- rubocop-rspec gem for ruby 2.3