### PR TITLE
Release 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## 0.0.2
+
+### Bugfixes
+- Moved the static analysis gems that were in shared to posix, since those gems have an additional ruby (devkit) requirement on Windows.
+
+## 0.0.1
+
+This is the initial release of the project.

--- a/config/info.yml
+++ b/config/info.yml
@@ -5,4 +5,4 @@ info:
   homepage: 'https://github.com/puppetlabs/puppet-module-gems'
   licenses: 'Apache-2.0'
   summary: 'A gem used to manage Puppet module dependencies.'
-  version: '0.0.1'
+  version: '0.0.2'


### PR DESCRIPTION
Includes a minor update to the dependencies config to accommodate the basic Windows environment not being able to install/build gem dependencies with native extensions unless Ruby Devkit or equivalent is installed.