### PR TITLE
(maint) pin unf_ext gem

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -60,6 +60,8 @@ dependencies:
           version: '<= 0.2.5'
         - gem: win32-service
           version: '<= 0.8.8'
+        - gem: unf_ext
+          version: '0.0.7.2'
       r2.1:
       r2.3:
     dev:


### PR DESCRIPTION
bundle install was failing on windows because of a new version of unf_ext wanting to install native extensions. this pins to version 0.0.7.2 on windows and linux.