### PR TITLE
(MODULES-4936) add rspec_junit_formatter

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -22,6 +22,8 @@ dependencies:
         - gem: rainbow
           version: '< 2.2.0'
         - gem: rubocop
+        - gem: rspec_junit_formatter
+          version: '~> 0.2'
       r2.1:
       r2.3:
         - gem: rubocop-rspec


### PR DESCRIPTION
this adds the rspec_junit_formatter as a shared dev gem. it is compatible with both posix and windows and we're currently using it on Jenkins for all unit tests. to expand to acceptance tests and cut down on Jenkins config clutter, i'm just sticking it in the bundle.