### PR TITLE
(MODULES-5135) Adding gettext-setup

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -11,6 +11,7 @@ dependencies:
           version: '< 1.2.0'
         - gem: parallel_tests
         - gem: pry
+        - gem: gettext-setup
         - gem: puppet-blacksmith
           version: '>= 3.4.0'
         - gem: puppet-lint


### PR DESCRIPTION
string_wrapper.rb exists in gettext-setup and  wraps all of the ruby strings to prepare them for translation.