### PR TITLE
(MAINT) Add example of using gems to build shared Docker images

### DIFF
--- a/docker/Dockerfile-puppet-4
+++ b/docker/Dockerfile-puppet-4
@@ -1,0 +1,13 @@
+FROM ruby:2.1.9
+
+ENV PUPPET_GEM_VERSION="~> 4.0"
+
+WORKDIR /module
+
+COPY Gemfile /bundle/Gemfile
+env BUNDLE_GEMFILE=/bundle/Gemfile
+RUN bundle install
+
+ENTRYPOINT ["bundle", "exec", "rake"]
+
+CMD ["-T"]

--- a/docker/Dockerfile-puppet-5
+++ b/docker/Dockerfile-puppet-5
@@ -1,0 +1,13 @@
+FROM ruby:2.4.0
+
+ENV PUPPET_GEM_VERSION="~> 5.0"
+
+WORKDIR /module
+
+COPY Gemfile /bundle/Gemfile
+env BUNDLE_GEMFILE=/bundle/Gemfile
+RUN bundle install
+
+ENTRYPOINT ["bundle", "exec", "rake"]
+
+CMD ["-T"]

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -1,0 +1,35 @@
+source 'https://rubygems.org'
+
+# Find a location or specific version for a gem. place_or_version can be a
+# version, which is most often used. It can also be git, which is specified as
+# `git://somewhere.git#branch`. You can also use a file source location, which
+# is specified as `file://some/location/on/disk`.
+def location_for(place_or_version, fake_version = nil)
+  if place_or_version =~ /^(git[:@][^#]*)#(.*)/
+    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+  elsif place_or_version =~ /^file:\/\/(.*)/
+    ['>= 0', { :path => File.expand_path($1), :require => false }]
+  else
+    [place_or_version, { :require => false }]
+  end
+end
+
+ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
+minor_version = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"  
+
+gem "puppet-module-posix-default-r#{minor_version}"
+
+gem "coveralls", require: false
+gem "rubycritic", require: false
+gem "simplecov-console", require: false
+
+gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
+
+group :development do
+  gem "puppet-module-posix-dev-r#{minor_version}"
+end
+
+group :system_tests do
+  gem "puppet-module-posix-system-r#{minor_version}"
+  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
+end

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,51 @@
+# Docker Images for Testing Puppet Modules
+
+It's reasonable to assume that using the gems from puppet-module-gems the fast majority of modules would have the asme Gemfile. This in turn means every run of `bundle install` against that Gemfile is a waste, apart from the first onefor each Ruby/Puppet version combination. By creating an publishing Docker images we can make tests more portable, by sharing the whole execution environment, and remove the need for a local Ruby setup completely into the bargain.
+
+This proof-of-concept provides two Dockerfiles, for Puppet 4.x and Puppet 5.x respectively. They use the relevant Ruby version from the AIO.
+
+
+## Building the images
+
+Let's build these images first. For this you will want to be in the `docker` directory where this README resides.
+
+```
+docker build -f Dockerfile-puppet-4 -t puppet/puppet-module:4 .
+docker build -f Dockerfile-puppet-5 -t puppet/puppet-module:5 .
+docker build -f Dockerfile-puppet-5 -t puppet/puppet-module:latest .
+```
+
+
+## Using the images
+
+Now checkout your favourite module. Let's run the `validate` checks against the image build module under Puppet 4.
+
+```
+git clone https://github.com/puppetlabs/puppetlabs-image_build.git
+cd puppetlabs-image_build
+docker run -v `pwd`:/module -it puppet/puppet-module:4 validate
+```
+
+Or lets run the `specs` against apache on Windows under Puppet 5: 
+
+```
+git clone https://github.com/puppetlabs/puppetlabs-image_build.git
+cd puppetlabs-image_build
+docker run -v ${PWD}:/module -it garethr/puppet-module:5 spec
+```
+
+Note that:
+
+* You don't need to install Ruby
+* You don't need to interact with Ruby developer tools like bundler
+* We ran tests against different Puppet versions and different Ruby versions
+
+
+## Next steps
+
+This is a proof-of-concept, it works nicely, but it would be possible to expand out from here to:
+
+* Provide more Puppet/Ruby version images
+* Provide alternative operating system images
+* Build native Windows images
+* Allow users to provide additional Gems to be installed

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Docker Images for Testing Puppet Modules
 
-It's reasonable to assume that using the gems from puppet-module-gems the fast majority of modules would have the asme Gemfile. This in turn means every run of `bundle install` against that Gemfile is a waste, apart from the first onefor each Ruby/Puppet version combination. By creating an publishing Docker images we can make tests more portable, by sharing the whole execution environment, and remove the need for a local Ruby setup completely into the bargain.
+It's reasonable to assume that using the gems from puppet-module-gems the fast majority of modules would have the same Gemfile. This in turn means every run of `bundle install` against that Gemfile is a waste, apart from the first one for each Ruby/Puppet version combination. By creating, and publishing Docker images we can make tests more portable, by sharing the whole execution environment, and remove the need for a local Ruby setup completely into the bargain.
 
 This proof-of-concept provides two Dockerfiles, for Puppet 4.x and Puppet 5.x respectively. They use the relevant Ruby version from the AIO.
 


### PR DESCRIPTION
The README covers the rationale for why I think this is useful. Opening a PR mainly for visibility and easy of trying this out. Rather than having the Dockerfiles hand rolled it would be possible to just generate them from the data structure already present in the repository for instance.

I've also pushed the images to my personal repository if anyone wants to test them out. https://hub.docker.com/r/garethr/puppet-module/

That means you should just be able to run (for instance)

```
git clone https://github.com/puppetlabs/puppetlabs-image_build.git
cd puppetlabs-image_build
docker run -v `pwd`:/module -it puppet/puppet-module:5 spec
```

I've not done it yet but this should work for Beaker as well. With the Docker backend if you mount the socket, and with the other hypervisors if you pass through the relevant config files or environment variables.