### PR TITLE
(PDK-487) Add semantic_puppet gem

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -22,6 +22,8 @@ dependencies:
           version: ['>= 2.4.1', '< 3.0.0']
         - gem: puppetlabs_spec_helper
           version: ['>= 2.3.1', '< 3.0.0']
+        - gem: semantic_puppet
+          version: '~> 1.0.1'
         - gem: specinfra
           version: '2.67.3'
         - gem: rspec-puppet


### PR DESCRIPTION
`semantic_puppet` is a soft dependency of `metadata-json-lint`.