### PR TITLE
Revert "(PDK-487) Add semantic_puppet gem"

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -22,8 +22,6 @@ dependencies:
           version: ['>= 2.4.1', '< 3.0.0']
         - gem: puppetlabs_spec_helper
           version: ['>= 2.3.1', '< 3.0.0']
-        - gem: semantic_puppet
-          version: '~> 1.0.1'
         - gem: specinfra
           version: '2.67.3'
         - gem: rspec-puppet


### PR DESCRIPTION
Since we still need to support early 5.x releases which conflict with
semantic_puppet, we cannot carry this yet.

This reverts commit 0772b4510eb6f2e802b04400e251b71d114320ac.