### PR TITLE
Remove puppet-lint-i18n

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -18,8 +18,6 @@ dependencies:
           version: '~> 0.26'
         - gem: puppet-lint
           version: ['>= 2.3.0', '< 3.0.0']
-        - gem: puppet-lint-i18n
-          version: '~> 1.0'
         - gem: puppet_pot_generator
           version: '~> 1.0'
         - gem: puppet-syntax


### PR DESCRIPTION
As this is a plug in for puppet-lint it automatically runs against the
code base resulting in puppet-lint failures. In order to resolve this
the plug-in needs to be removed. It can be implemented on a per module
basis.