### PR TITLE
Release prep for 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Removes `puppet-lint-i18n` from managed dependencies.
+
 ## 0.2.0
 
 - Adds gems needed for i18n development and testing.

--- a/config/info.yml
+++ b/config/info.yml
@@ -5,4 +5,4 @@ info:
   homepage: 'https://github.com/puppetlabs/puppet-module-gems'
   licenses: 'Apache-2.0'
   summary: 'A gem used to manage Puppet module dependencies.'
-  version: '0.2.0'
+  version: '0.2.1'


### PR DESCRIPTION
This release removes `puppet-lint-i18n` dependency.