### PR TITLE
Unpin rainbow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+- Loosen the pin on rainbow
+
 ## 0.2.1
 
 - Removes `puppet-lint-i18n` from managed dependencies.

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -25,7 +25,7 @@ dependencies:
         - gem: puppetlabs_spec_helper
           version: ['>= 2.3.1', '< 3.0.0']
         - gem: rainbow
-          version: ['>= 2.0.0', '< 2.2.0']
+          version: '~> 2.0'
         - gem: rspec-puppet
           version: ['>= 2.3.2', '< 3.0.0']
         - gem: rspec-puppet-facts

--- a/config/info.yml
+++ b/config/info.yml
@@ -5,4 +5,4 @@ info:
   homepage: 'https://github.com/puppetlabs/puppet-module-gems'
   licenses: 'Apache-2.0'
   summary: 'A gem used to manage Puppet module dependencies.'
-  version: '0.2.1'
+  version: '0.2.2'


### PR DESCRIPTION
2.2.0 was a broken release so we pinned < 2.2.0, but that is fixed now.

rubocop is still pinned at a version that has rainbow < 3.0.0.