### PR TITLE
(RE-9907) Migrate from stickler to artifactory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 group :development do
   gem 'pry',                    :require => false
   gem 'pry-byebug',             :require => false
-  gem 'stickler'
 end
 
 group :unit_test do

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ And for example, the gemspec for `test-gem-first-a-1.0.0.gem` will include depen
 - Run `bundle exec exe/build-gems.rb` to build the gems into the `pkg` directory.
 - Validate that the gems have build correctly.
 **The next step requires that you have Ownership permissions for these gems on rubygems.org, also requires access to internal Puppet network.**
-- Run `bundle exec exe/push-gems.rb` to update owners and publish to rubygems.org, as well as internal puppet stickler mirror.
+- Run `bundle exec exe/push-gems.rb` to update owners and publish to rubygems.org.
 - Tag the version and push tags to github.
   - e.g. `git tag -a 0.1.2 -m "0.1.2"`
   - e.g. `git push upstream --tags`

--- a/exe/push-gems.rb
+++ b/exe/push-gems.rb
@@ -15,8 +15,6 @@ OWNERS = [
 "helen@puppet.com"
 ]
 
-STICKLER_MIRROR = 'http://rubygems.delivery.puppetlabs.net'.freeze
-
 Dir["#{PKG_PATH}/*.gem"].each do |file|
   gem = File.basename(file).split('.gem').first
   gem_version = gem.split('-').last
@@ -30,9 +28,5 @@ Dir["#{PKG_PATH}/*.gem"].each do |file|
 
   puts "## Pushing #{gem_name} to https://rubygems.org."
   value = `gem push #{file}`
-  puts value
-
-  puts "## Mirroring #{gem_name} to #{STICKLER_MIRROR}."
-  value = `stickler mirror --server #{STICKLER_MIRROR} #{gem_name} --gem-version #{gem_version}`
   puts value
 end


### PR DESCRIPTION
I removed the call to push to stickler because we already mirror rubygems.org on artifactory