### PR TITLE
(maint) add puppet-strings to shared dev deps

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -22,6 +22,8 @@ dependencies:
           version: ['>= 2.3.0', '< 3.0.0']
         - gem: puppet_pot_generator
           version: '~> 1.0'
+        - gem: puppet-strings
+          version: '~> 2.0'
         - gem: puppet-syntax
           version: ['>= 2.4.1', '< 3.0.0']
         - gem: puppetlabs_spec_helper


### PR DESCRIPTION
If we want to encourage the use of Puppet Strings, we should include it in our standard toolset. It is currently not in puppet-module-gems but it seems like a good place for it. This change adds it to the shared dev dependency list.