### PR TITLE
(maint) Downgrade Bundler from 1.16.3

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -8,6 +8,8 @@ dependencies:
       r2.5:
     dev:
       shared:
+        - gem: bundler
+          version: '< 1.16.3'
         - gem: codecov
           version: '~> 0.1.10'
         - gem: gettext-setup


### PR DESCRIPTION
We are seeing https://github.com/bundler/bundler/issues/6629 in Travis CI