### PR TITLE
(MODULES-8138) - Bump of specinfra to work with Sles 15

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -49,7 +49,7 @@ dependencies:
         - gem: simplecov-console
           version: '~> 0.4.2'
         - gem: specinfra
-          version: '2.67.3'
+          version: '2.76.3'
       r2.1:
         - gem: net-telnet
           version: '~> 0.1.1'


### PR DESCRIPTION
Sles 15 requires a newer version of the gem as the way in which it checks for the sles version is no longer the same.