### PR TITLE
(MODULES-8770) Add dependency_checker gem

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -10,6 +10,8 @@ dependencies:
       shared:
         - gem: codecov
           version: '~> 0.1.10'
+        - gem: dependency_checker
+          version: '~> 0.2'
         - gem: gettext-setup
           version: '~> 0.26'
         - gem: metadata-json-lint


### PR DESCRIPTION
This change adds the [dependency checker](https://github.com/puppetlabs/dependency_checker) gem, allowing us to verify the impact of version bumps on our modules during pre-release. I have tested the changes against the following modules with no issues (see spoilers for adhoc results):
<details><summary>puppetlabs-accounts</summary>
<img width="1066" alt="Screen Shot 2019-03-25 at 09 22 51" src="https://user-images.githubusercontent.com/24768276/54908432-cddd0b80-4edf-11e9-8d9f-88b19bb2309c.png">
</details>
<details><summary>puppetlabs-acl</summary>
<img width="1062" alt="Screen Shot 2019-03-25 at 09 23 11" src="https://user-images.githubusercontent.com/24768276/54908445-d6354680-4edf-11e9-812a-6884db5012c5.png">
</details>
<details><summary>puppetlabs-iis</summary>
<img width="1059" alt="Screen Shot 2019-03-25 at 09 23 22" src="https://user-images.githubusercontent.com/24768276/54908459-dcc3be00-4edf-11e9-99b9-4b00999dfe66.png">
</details>
<details><summary>puppetlabs-stdlib</summary>
<img width="1060" alt="Screen Shot 2019-03-25 at 09 23 59" src="https://user-images.githubusercontent.com/24768276/54908477-e3eacc00-4edf-11e9-841f-829454a0046b.png">
</details>




