### PR TITLE
(MODULES-7469) Bump specinfra to 2.77.1

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -51,7 +51,7 @@ dependencies:
         - gem: simplecov-console
           version: '~> 0.4.2'
         - gem: specinfra
-          version: '2.76.7'
+          version: '2.77.1'
       r2.1:
         - gem: net-telnet
           version: '~> 0.1.1'


### PR DESCRIPTION
This version bump has been added to consume changes in the most recent release of specinfra which provide fixes for SLES 11 and Solaris 11 test failures on https://github.com/puppetlabs/puppetlabs-accounts/pull/221. 

Tested out on the following modules successfully:
<details><summary>puppetlabs-accounts</summary>
<img width="1068" alt="Screen Shot 2019-05-03 at 14 26 28" src="https://user-images.githubusercontent.com/24768276/57144769-b421c480-6db9-11e9-8fdd-354a9bf58d5c.png">
</details>
<details><summary>puppetlabs-acl</summary>
<img width="1068" alt="Screen Shot 2019-05-03 at 15 16 04" src="https://user-images.githubusercontent.com/24768276/57144814-d4ea1a00-6db9-11e9-989f-b1a56a2d413b.png">
</details>
<details><summary>puppetlabs-iis</summary>
<img width="1072" alt="Screen Shot 2019-05-03 at 15 39 47" src="https://user-images.githubusercontent.com/24768276/57144825-dd425500-6db9-11e9-8e02-115eef190d9d.png">
</details>
<details><summary>puppetlabs-stdlib</summary>
<img width="1063" alt="Screen Shot 2019-05-03 at 14 26 15" src="https://user-images.githubusercontent.com/24768276/57144802-c865c180-6db9-11e9-8373-1b9d0bf81328.png">
</details>