### PR TITLE
(PDK-1465) Add net-ssh to ruby 2.1 for system tests

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -113,6 +113,8 @@ dependencies:
       r2.1:
         - gem: fog-openstack
           version: '0.1.25'
+        - gem: net-ssh
+          version: '~> 4.2.0' # Required for older Ruby version
       r2.3:
       r2.4:
       r2.5:


### PR DESCRIPTION
Beaker requires net-ssh however for older ruby versions this needs to be pinned
to and old version of net-ssh.  This commit adds net-ssh to the old Ruby 2.1
gems, with a version pin.