### PR TITLE
MODULES-9742 fix github_changelog_generator dependencies

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -9,6 +9,8 @@ dependencies:
       r2.6:
     dev:
       shared:
+        - gem: activesupport
+          version: ['>=5.0.0', '< 6.0.0']
         - gem: codecov
           version: '~> 0.1.10'
         - gem: dependency_checker

--- a/config/info.yml
+++ b/config/info.yml
@@ -5,4 +5,4 @@ info:
   homepage: 'https://github.com/puppetlabs/puppet-module-gems'
   licenses: 'Apache-2.0'
   summary: 'A gem used to manage Puppet module dependencies.'
-  version: '0.4.1'
+  version: '0.4.2'

--- a/config/info.yml
+++ b/config/info.yml
@@ -1,8 +1,0 @@
-info:
-  prefix: 'puppet-module'
-  authors: 'Puppet, Inc.'
-  email: 'puppet-module-gems-maintainers@puppet.com'
-  homepage: 'https://github.com/puppetlabs/puppet-module-gems'
-  licenses: 'Apache-2.0'
-  summary: 'A gem used to manage Puppet module dependencies.'
-  version: '0.4.2'


### PR DESCRIPTION
the latest version of activesupport (6.0.0) requires Ruby 2.5.0 or newer -> introduces a breaking change and is no longer compatible with ruby_version < 2.5.0.
In order to keep it working with ruby 2.3.1, I specified the version for activesupport (5.2.3) 