### PR TITLE
Release prep for v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.3
+
+- Update version range for facterdb to '>= 0.8.1', '< 2.0.0'
+- Bump of rspec-puppet-facts to ~> 1.10.0
+- Bump of specinfra version to support EL8
+- Add puppet-debugger to development gems
+
 ## 0.4.2
 
 - Add net-ssh to ruby 2.1 for system tests

--- a/config/info.yml
+++ b/config/info.yml
@@ -5,4 +5,4 @@ info:
   homepage: 'https://github.com/puppetlabs/puppet-module-gems'
   licenses: 'Apache-2.0'
   summary: 'A gem used to manage Puppet module dependencies.'
-  version: '0.4.2'
+  version: '0.4.3'


### PR DESCRIPTION
## Release prep for v0.4.3
See CHANGELOG for details of changes since `0.4.2`
### Testing
Tested against the following modules:
- `puppetlabs-acl`
- `puppetlabs-registry`
- `puppetlabs-stdlib`