### PR TITLE
Avoid concurrent-ruby 1.1.6 which is triggering MRI segfaults

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -13,6 +13,9 @@ dependencies:
           version: ['>=5.0.0', '< 6.0.0']
         - gem: codecov
           version: '~> 0.1.10'
+        - gem: 'concurrent-ruby'
+          version: '!= 1.1.6'
+          reason: 'https://github.com/ruby-concurrency/concurrent-ruby/issues/849'
         - gem: dependency_checker
           version: '~> 0.2'
         - gem: facterdb
@@ -30,7 +33,7 @@ dependencies:
         - gem: pry
           version: '~> 0.10.4'
         - gem: puppet-debugger
-          version: '~> 0.14'  
+          version: '~> 0.14'
         - gem: puppet-lint
           version: ['>= 2.3.0', '< 3.0.0']
         - gem: puppet_pot_generator


### PR DESCRIPTION
See https://github.com/ruby-concurrency/concurrent-ruby/issues/849 for details.

I've ran a survey over supported modules and no further segfaults occurred when using concurrent-ruby 1.1.5.