### PR TITLE
(IAC-557) Release prep 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.4
+
+- Avoid concurrent-ruby 1.1.6 which is triggering MRI segfaults 
+
 ## 0.4.3
 
 - Update version range for facterdb to '>= 0.8.1', '< 2.0.0'

--- a/config/info.yml
+++ b/config/info.yml
@@ -5,4 +5,4 @@ info:
   homepage: 'https://github.com/puppetlabs/puppet-module-gems'
   licenses: 'Apache-2.0'
   summary: 'A gem used to manage Puppet module dependencies.'
-  version: '0.4.3'
+  version: '0.4.4'


### PR DESCRIPTION
Release prep for 0.4.4
See CHANGELOG for details of changes since 0.4.3

Testing in progress
Tested against the following modules:

Successful Release checks and travis/apveyor
https://github.com/puppetlabs/puppetlabs-motd/pull/290
https://github.com/puppetlabs/puppetlabs-reboot/pull/234

Successful Travis/appveyor
https://github.com/puppetlabs/puppetlabs-acl/pull/182
https://github.com/puppetlabs/puppetlabs-stdlib/pull/1092

Acceptance tests running successfully on release checks for and also ran locally the spec tests 2.5.3 and acceptance tests on puppet agent5.All ran clean.(Screenshots of results are attached with modules PR)
https://github.com/puppetlabs/puppetlabs-stdlib/pull/1092
Opened ticket for spec tests failures for 2.6.3 on release checks.

Acceptance tests running successfully locally for acl module(Attached screenshot with the PR)