### PR TITLE
(IAC-858) Add ruby 2.7 and other cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,61 @@
+---
+os: linux
 language: ruby
-script: "bundle exec rspec spec"
+cache: bundler
+
+stages:
+  - smoke
+  - test
+
+rvm:
+  - 2.7
+  - 2.5
+  - 2.4
+  - 2.3
+  - 2.1
+
+env:
+  - SET=dev
+  - SET=system
+
+script: |
+  # test installing the gems from $SET on this ruby version
+  set -e
+
+  echo create gems
+  bundle exec ./exe/build-gems.rb
+
+  mkdir test
+  cd test
+  export BUNDLE_GEMFILE=./Gemfile
+
+  cat <<EOF >Gemfile
+  source 'https://rubygems.org'
+  ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
+  minor_version = ruby_version_segments[0..1].join('.')
+  gem "puppet-module-posix-default-r#{minor_version}", :path => '../pkg'
+  gem "puppet-module-posix-dev-r#{minor_version}",     :path => '../pkg'
+  gem "puppet-module-posix-system-r#{minor_version}",  :path => '../pkg' if ENV['SET'] == 'system'
+  EOF
+
+  echo setting up gem path for caching
+  bundle config path ../vendor/bundle
+
+  cat Gemfile
+
+  echo testing installability of the puppet-module-gems
+  bundle install
+
+  cat Gemfile.lock
+
+jobs:
+  include:
+    - stage: smoke
+      name: "Make sure that gems build"
+      script: bundle exec ./exe/build-gems.rb
+    - stage: smoke
+      name: "Unit Tests"
+      script: bundle exec rspec spec
+
 notifications:
   email: false
-rvm:
-  - 2.3.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,66 @@
+---
+version: 1.1.x.{build}
+
+cache:
+  - vendor/bundle
+
+environment:
+  matrix:
+    - RUBY_VERSION: 21-x64
+      SET: dev
+    - RUBY_VERSION: 21-x64
+      SET: system
+    - RUBY_VERSION: 23-x64
+      SET: dev
+    - RUBY_VERSION: 23-x64
+      SET: system
+    - RUBY_VERSION: 24-x64
+      SET: dev
+    - RUBY_VERSION: 24-x64
+      SET: system
+    - RUBY_VERSION: 25-x64
+      SET: dev
+    - RUBY_VERSION: 25-x64
+      SET: system
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle install --jobs 4 --retry 2
+  - bundle exec rspec spec
+  - bundle exec ruby ./exe/build-gems.rb
+
+build: off
+
+test_script:
+  - ps: |
+      New-Item test -ItemType Directory
+
+      Set-Location test
+
+      Set-Content Gemfile -Value @'
+      source 'https://rubygems.org'
+      ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
+      minor_version = ruby_version_segments[0..1].join('.')
+      gem "puppet-module-posix-default-r#{minor_version}", :path => '../pkg'
+      gem "puppet-module-posix-dev-r#{minor_version}",     :path => '../pkg'
+      gem "puppet-module-posix-system-r#{minor_version}",  :path => '../pkg' if ENV['SET'] == 'system'
+      '@
+
+      Write-Host "setting up gem path for caching"
+      & bundle config path ../vendor/bundle
+      if ($LastExitCode -ne 0) { exit $LastExitCode }
+
+      Get-Content ./Gemfile | Write-Host
+      Write-Host "testing installability of the puppet-module-gems"
+      & bundle install
+      if ($LastExitCode -ne 0) { exit $LastExitCode }
+
+      Get-Content ./Gemfile.lock | Write-Host
+
+notifications:
+  - provider: Email
+    to:
+      - nobody@example.com
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -18,6 +18,7 @@ dependencies:
           reason: 'used by puppet and many others; skip 1.1.6 because of this issue: https://github.com/ruby-concurrency/concurrent-ruby/issues/849'
         - gem: dependency_checker
           version: '~> 0.2'
+          reason: 'part of the default toolset install'
         - gem: facterdb
           version: ['>= 0.8.1', '< 2.0.0']
         - gem: gettext-setup

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -12,6 +12,7 @@ dependencies:
       shared:
         - gem: codecov
           version: '~> 0.1.10'
+          reason: 'used for coverage reporting; 0.1.10 stopped failing the build on upload failures'
         - gem: 'concurrent-ruby'
           version: '!= 1.1.6'
           reason: 'https://github.com/ruby-concurrency/concurrent-ruby/issues/849'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -94,10 +94,16 @@ dependencies:
           version: '~> 0.1.1'
         - gem: i18n
           version: ['>= 1.0.0', '< 1.5.2']
+        - gem: simplecov
+          version: '< 0.18.0'
+          reason: "part of the default toolset install; v0.18 requires ruby 2.4 or later"
       r2.3:
         - gem: activesupport
           version: ['>=5.0.0', '< 6.0.0']
           reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
+        - gem: simplecov
+          version: '< 0.18.0'
+          reason: "part of the default toolset install; v0.18 requires ruby 2.4 or later"
       r2.4:
         - gem: activesupport
           version: ['>=5.0.0', '< 6.0.0']

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -68,13 +68,13 @@ dependencies:
           reason: 'part of the default toolset install'
         - gem: rubocop
           version: '~> 0.49.0'
-          reason: 'part of the default toolset install'
+          reason: 'part of the default toolset install; pinned to this specific version as this is what the pdk-templates are using'
         - gem: rubocop-i18n
           version: '~> 1.2.0'
-          reason: 'part of the default toolset install'
+          reason: 'part of the default toolset install; pinned to this specific version as this is what the pdk-templates are using'
         - gem: rubocop-rspec
           version: '~> 1.16.0'
-          reason: 'part of the default toolset install'
+          reason: 'part of the default toolset install; pinned to this specific version as this is what the pdk-templates are using'
         - gem: rspec_junit_formatter
           version: '~> 0.2'
         - gem: serverspec

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -86,6 +86,9 @@ dependencies:
           version: '2.82.2'
           reason: 'part of the default toolset install'
       r2.1:
+        - gem: net-ssh
+          version: '~> 4.2.0'
+          reason: "older version required for Ruby 2.1"
         - gem: net-telnet
           version: '~> 0.1.1'
         - gem: i18n
@@ -163,7 +166,8 @@ dependencies:
         - gem: fog-openstack
           version: '0.1.25'
         - gem: net-ssh
-          version: '~> 4.2.0' # Required for older Ruby version
+          version: '~> 4.2.0'
+          reason: "Required for Ruby 2.1"
       r2.3:
       r2.4:
       r2.5:

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -183,8 +183,6 @@ dependencies:
       r2.7:
     dev:
       shared:
-        - gem: simplecov
-          version: ['>= 0.14.1', '< 1.0.0']
         - gem: puppet-blacksmith
           version: '>= 3.4.0'
           reason: 'part of the default toolset install'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -193,6 +193,12 @@ dependencies:
       r2.7:
     dev:
       shared:
+        - gem: ed25519
+          version: '~> 1.2'
+          reason: 'required for ed25519 keys when using bolt, but fails building on windows in bolt and pdk native packaging; see https://tickets.puppetlabs.com/browse/BOLT-1296 and puppetlabs/bolt#1337 for details.'
+        - gem: bcrypt_pbkdf
+          version: '~> 1.0'
+          reason: 'required for ed25519 keys when using bolt, but fails building on windows in bolt and pdk native packaging; see https://tickets.puppetlabs.com/browse/BOLT-1296 and puppetlabs/bolt#1337 for details.'
       r2.1:
         - gem: puppet-blacksmith
           version: '< 5.0'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -7,6 +7,7 @@ dependencies:
       r2.4:
       r2.5:
       r2.6:
+      r2.7:
     dev:
       shared:
         - gem: activesupport
@@ -79,6 +80,9 @@ dependencies:
       r2.6:
         - gem: puppet_litmus
           version: ['>= 0.4.0', '< 1.0.0']
+      r2.7:
+        - gem: puppet_litmus
+          version: ['>= 0.4.0', '< 1.0.0']
     system:
       shared:
         - gem: beaker-i18n_helper
@@ -128,6 +132,7 @@ dependencies:
       r2.4:
       r2.5:
       r2.6:
+      r2.7:
   posix:
     default:
       r2.1:
@@ -135,6 +140,7 @@ dependencies:
       r2.4:
       r2.5:
       r2.6:
+      r2.7:
     dev:
       shared:
         - gem: simplecov
@@ -146,12 +152,14 @@ dependencies:
       r2.4:
       r2.5:
       r2.6:
+      r2.7:
     system:
       r2.1:
       r2.3:
       r2.4:
       r2.5:
       r2.6:
+      r2.7:
   win:
     default:
       shared:
@@ -162,15 +170,18 @@ dependencies:
       r2.4:
       r2.5:
       r2.6:
+      r2.7:
     dev:
       r2.1:
       r2.3:
       r2.4:
       r2.5:
       r2.6:
+      r2.7:
     system:
       r2.1:
       r2.3:
       r2.4:
       r2.5:
       r2.6:
+      r2.7:

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -175,6 +175,9 @@ dependencies:
         - gem: net-ssh
           version: '~> 4.2.0'
           reason: "Required for Ruby 2.1"
+        - gem: nokogiri
+          version: '< 1.10.0'
+          reason: "Ruby 2.1 support was dropped in 1.10.0"
       r2.3:
       r2.4:
       r2.5:

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -50,7 +50,6 @@ dependencies:
           version: '~> 2.0'
           reason: 'part of the default toolset install'
         - gem: puppet-resource_api
-          version: '~> 1.6' # 1.6 is still supported for puppet6/johnson/2019.0 until August 2019
           reason: 'part of the default toolset install'
         - gem: puppet-syntax
           version: ['>= 2.4.1', '< 3.0.0']

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -10,8 +10,6 @@ dependencies:
       r2.7:
     dev:
       shared:
-        - gem: activesupport
-          version: ['>=5.0.0', '< 6.0.0']
         - gem: codecov
           version: '~> 0.1.10'
         - gem: 'concurrent-ruby'
@@ -73,14 +71,29 @@ dependencies:
         - gem: i18n
           version: ['>= 1.0.0', '< 1.5.2']
       r2.3:
+        - gem: activesupport
+          version: ['>=5.0.0', '< 6.0.0']
+          reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
       r2.4:
+        - gem: activesupport
+          version: ['>=5.0.0', '< 6.0.0']
+          reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
       r2.5:
         - gem: puppet_litmus
           version: ['>= 0.4.0', '< 1.0.0']
+        - gem: activesupport
+          version: ['>=5.0.0', '< 6.0.0']
+          reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
       r2.6:
+        - gem: activesupport
+          version: '~> 6.0'
+          reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
         - gem: puppet_litmus
           version: ['>= 0.4.0', '< 1.0.0']
       r2.7:
+        - gem: activesupport
+          version: '~> 6.0'
+          reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
         - gem: puppet_litmus
           version: ['>= 0.4.0', '< 1.0.0']
     system:

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -34,8 +34,6 @@ dependencies:
         - gem: parallel_tests
           version: ['>= 2.14.1', '< 2.14.3']
           reason: 'part of the default toolset install'
-        - gem: parser
-          version: '~> 2.5.1.2'
         - gem: pry
           version: '~> 0.10.4'
           reason: 'part of the default toolset install'

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -50,6 +50,7 @@ dependencies:
           version: '~> 2.0'
           reason: 'part of the default toolset install'
         - gem: puppet-resource_api
+          version: '~> 1.8'
           reason: 'part of the default toolset install'
         - gem: puppet-syntax
           version: ['>= 2.4.1', '< 3.0.0']
@@ -183,15 +184,30 @@ dependencies:
       r2.7:
     dev:
       shared:
-        - gem: puppet-blacksmith
-          version: '>= 3.4.0'
-          reason: 'part of the default toolset install'
       r2.1:
+        - gem: puppet-blacksmith
+          version: '< 5.0'
+          reason: 'part of the default toolset install; 5.0 dropped ruby <2.4 support'
       r2.3:
+        - gem: puppet-blacksmith
+          version: '< 5.0'
+          reason: 'part of the default toolset install; 5.0 dropped ruby <2.4 support'
       r2.4:
+        - gem: puppet-blacksmith
+          version: '~> 6.0'
+          reason: 'part of the default toolset install; 5.0 dropped ruby <2.4 support'
       r2.5:
+        - gem: puppet-blacksmith
+          version: '~> 6.0'
+          reason: 'part of the default toolset install; 5.0 dropped ruby <2.4 support'
       r2.6:
+        - gem: puppet-blacksmith
+          version: '~> 6.0'
+          reason: 'part of the default toolset install; 5.0 dropped ruby <2.4 support'
       r2.7:
+        - gem: puppet-blacksmith
+          version: '~> 6.0'
+          reason: 'part of the default toolset install; 5.0 dropped ruby <2.4 support'
     system:
       r2.1:
       r2.3:

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -12,7 +12,7 @@ dependencies:
       shared:
         - gem: codecov
           version: '~> 0.1.10'
-          reason: 'used for coverage reporting; 0.1.10 stopped failing the build on upload failures'
+          reason: 'part of the default toolset install; 0.1.10 stopped failing the build on upload failures'
         - gem: 'concurrent-ruby'
           version: '!= 1.1.6'
           reason: 'used by puppet and many others; skip 1.1.6 because of this issue: https://github.com/ruby-concurrency/concurrent-ruby/issues/849'
@@ -21,52 +21,73 @@ dependencies:
           reason: 'part of the default toolset install'
         - gem: facterdb
           version: ['>= 0.8.1', '< 2.0.0']
+          reason: 'part of the default toolset install'
         - gem: gettext-setup
           version: '~> 0.26'
+          reason: 'part of the default toolset install'
         - gem: metadata-json-lint
           version: ['>= 2.0.2', '< 3.0.0']
+          reason: 'part of the default toolset install'
         - gem: mocha
           version: ['>= 1.0.0', '< 1.2.0']
+          reason: 'part of the legacy toolset install; some breakage with 1.2.0 made us stop updating'
         - gem: parallel_tests
           version: ['>= 2.14.1', '< 2.14.3']
+          reason: 'part of the default toolset install'
         - gem: parser
           version: '~> 2.5.1.2'
         - gem: pry
           version: '~> 0.10.4'
+          reason: 'part of the default toolset install'
         - gem: puppet-debugger
           version: '~> 0.18'
+          reason: 'part of the default toolset install'
         - gem: puppet-lint
           version: ['>= 2.3.0', '< 3.0.0']
+          reason: 'part of the default toolset install'
         - gem: puppet_pot_generator
           version: '~> 1.0'
+          reason: 'part of the default toolset install'
         - gem: puppet-strings
           version: '~> 2.0'
+          reason: 'part of the default toolset install'
         - gem: puppet-resource_api
           version: '~> 1.6' # 1.6 is still supported for puppet6/johnson/2019.0 until August 2019
+          reason: 'part of the default toolset install'
         - gem: puppet-syntax
           version: ['>= 2.4.1', '< 3.0.0']
+          reason: 'part of the default toolset install'
         - gem: puppetlabs_spec_helper
           version: ['>= 2.9.0', '< 3.0.0']
+          reason: 'part of the default toolset install'
         - gem: rainbow
           version: '~> 2.0'
         - gem: rspec-puppet
           version: ['>= 2.3.2', '< 3.0.0']
+          reason: 'part of the default toolset install'
         - gem: rspec-puppet-facts
           version: '~> 1.10.0'
+          reason: 'part of the default toolset install'
         - gem: rubocop
           version: '~> 0.49.0'
+          reason: 'part of the default toolset install'
         - gem: rubocop-i18n
           version: '~> 1.2.0'
+          reason: 'part of the default toolset install'
         - gem: rubocop-rspec
           version: '~> 1.16.0'
+          reason: 'part of the default toolset install'
         - gem: rspec_junit_formatter
           version: '~> 0.2'
         - gem: serverspec
           version: '~> 2.41'
+          reason: 'part of the default toolset install'
         - gem: simplecov-console
           version: '~> 0.4.2'
+          reason: 'part of the default toolset install'
         - gem: specinfra
           version: '2.82.2'
+          reason: 'part of the default toolset install'
       r2.1:
         - gem: net-telnet
           version: '~> 0.1.1'
@@ -81,23 +102,26 @@ dependencies:
           version: ['>=5.0.0', '< 6.0.0']
           reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
       r2.5:
-        - gem: puppet_litmus
-          version: ['>= 0.4.0', '< 1.0.0']
         - gem: activesupport
           version: ['>=5.0.0', '< 6.0.0']
           reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
+        - gem: puppet_litmus
+          version: ['>= 0.4.0', '< 1.0.0']
+          reason: 'part of the default toolset install; requires ruby 2.5 or later (for bolt)'
       r2.6:
         - gem: activesupport
           version: '~> 6.0'
           reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
         - gem: puppet_litmus
           version: ['>= 0.4.0', '< 1.0.0']
+          reason: 'part of the default toolset install; requires ruby 2.5 or later (for bolt)'
       r2.7:
         - gem: activesupport
           version: '~> 6.0'
           reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
         - gem: puppet_litmus
           version: ['>= 0.4.0', '< 1.0.0']
+          reason: 'part of the default toolset install; requires ruby 2.5 or later (for bolt)'
     system:
       shared:
         - gem: beaker-i18n_helper
@@ -162,6 +186,7 @@ dependencies:
           version: ['>= 0.14.1', '< 1.0.0']
         - gem: puppet-blacksmith
           version: '>= 3.4.0'
+          reason: 'part of the default toolset install'
       r2.1:
       r2.3:
       r2.4:

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -15,7 +15,7 @@ dependencies:
           reason: 'used for coverage reporting; 0.1.10 stopped failing the build on upload failures'
         - gem: 'concurrent-ruby'
           version: '!= 1.1.6'
-          reason: 'https://github.com/ruby-concurrency/concurrent-ruby/issues/849'
+          reason: 'used by puppet and many others; skip 1.1.6 because of this issue: https://github.com/ruby-concurrency/concurrent-ruby/issues/849'
         - gem: dependency_checker
           version: '~> 0.2'
         - gem: facterdb


### PR DESCRIPTION
The "other cleanups" are splitting out some gems into specific version pins for the different ruby versions so that more recent versions can be used, and removing some redundant pins.

Fixes #127 ; fixes #118 