### PR TITLE
(IAC-1074) Pin simplecov to '< 0.19.0' on Ruby 2.4

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -108,6 +108,9 @@ dependencies:
         - gem: activesupport
           version: ['>=5.0.0', '< 6.0.0']
           reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
+        - gem: simplecov
+          version: '< 0.19.0'
+          reason: 'simplecov dropped support for Ruby 2.4 from v0.19.0 onwards'
       r2.5:
         - gem: activesupport
           version: ['>=5.0.0', '< 6.0.0']

--- a/config/info.yml
+++ b/config/info.yml
@@ -5,4 +5,4 @@ info:
   homepage: 'https://github.com/puppetlabs/puppet-module-gems'
   licenses: 'Apache-2.0'
   summary: 'A set of gems declaring Puppet module dependencies.'
-  version: '0.5.0'
+  version: '0.5.1'


### PR DESCRIPTION
### Description
`simplecov` dropped support for Ruby 2.4 from version `v0.19.0` onwards:
https://github.com/simplecov-ruby/simplecov/releases/tag/v0.19.0

Closes puppetlabs/pdk-templates#345
### Tests
- [x] `simpecov` version `0.18.5` installs in Ruby 2.4 environment
- [x] `bundle exec rake spec:simplecov` runs in Ruby 2.4 enviroment
- [x] `simpecov` version `0.19.0` installs in Ruby 2.5 environment