### PR TITLE
Allow rspec-puppet-facts v2

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -64,7 +64,7 @@ dependencies:
           version: ['>= 2.3.2', '< 3.0.0']
           reason: 'part of the default toolset install'
         - gem: rspec-puppet-facts
-          version: '~> 1.10.0'
+          version: ['>= 1.10.0', '< 3']
           reason: 'part of the default toolset install'
         - gem: rubocop
           version: '~> 0.49.0'


### PR DESCRIPTION
Verified this version working with puppetlabs-apache unit tests. See https://github.com/mcanevet/rspec-puppet-facts/pull/122