### PR TITLE
Remove rspec-expectations pin

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -57,9 +57,6 @@ dependencies:
           reason: 'part of the default toolset install'
         - gem: rainbow
           version: '~> 2.0'
-        - gem: rspec-expectations
-          version: ['< 3.10.0']
-          reason: 'avoid breaking change until https://github.com/rodjek/rspec-puppet/pull/811 is released'
         - gem: rspec-puppet
           version: ['>= 2.3.2', '< 3.0.0']
           reason: 'part of the default toolset install'


### PR DESCRIPTION
Since https://github.com/rodjek/rspec-puppet/pull/811 has been released as part of rspec-puppet 2.8.0, we can drop this pin again.