### PR TITLE
(IAC-1233) Remove litmus as a dependency in Ruby 2.5 & 2.6

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -124,9 +124,6 @@ dependencies:
         - gem: activesupport
           version: ['>=5.0.0', '< 6.0.0']
           reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
-        - gem: puppet_litmus
-          version: ['>= 0.4.0', '< 1.0.0']
-          reason: 'part of the default toolset install; requires ruby 2.5 or later (for bolt)'
         - gem: simplecov
           version: '< 0.19.0'
           reason: "0.19.0 is causing builds to hang on TravisCI"
@@ -137,9 +134,6 @@ dependencies:
         - gem: activesupport
           version: '~> 6.0'
           reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
-        - gem: puppet_litmus
-          version: ['>= 0.4.0', '< 1.0.0']
-          reason: 'part of the default toolset install; requires ruby 2.5 or later (for bolt)'
         - gem: simplecov
           version: '< 0.19.0'
           reason: "0.19.0 is causing builds to hang on TravisCI"

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -146,7 +146,7 @@ dependencies:
           reason: "required by github_changelog_generator; v6 requires ruby 2.5 or later"
         - gem: puppet_litmus
           version: ['>= 0.4.0', '< 1.0.0']
-          reason: 'part of the default toolset install; requires ruby 2.5 or later (for bolt)'
+          reason: 'part of the default toolset install; requires ruby 2.7 or later (for bolt and puppet6/7)'
         - gem: simplecov
           version: '< 0.19.0'
           reason: "0.19.0 is causing builds to hang on TravisCI"


### PR DESCRIPTION
## Description

With the release of Puppet 7, we will soon run in to issues on our
CI pipelines for the Puppet supported modules, as bolt has quite
a narrow band of support for what version Puppet it supports.

There is no requirement for us to depend on Litmus -> Bolt for spec
test execution on Ruby 2.5 / Puppet 6 and acceptance tests can run
on any Ruby version.

This change removes Litmus as a dependency on Ruby 2.5 and 2.6 to
facilitate Puppet 5, 6 & 7 spec and acceptance test execution on the
supported modules CI pipelines.

It would be advised that the next release of this gem be a minor version
bump (i.e. `0.6`) given the significance of the change.

## Testing

Tested against the [`puppetlabs-motd` module](https://github.com/puppetlabs/puppetlabs-motd/pull/357) on [TravisCI](https://github.com/puppetlabs/puppetlabs-motd/pull/357/checks?check_run_id=1395948454)