### PR TITLE
Update metadata-json-lint pin to allow 3.x release train

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -26,7 +26,7 @@ dependencies:
           version: '~> 0.26'
           reason: 'part of the default toolset install'
         - gem: metadata-json-lint
-          version: ['>= 2.0.2', '< 3.0.0']
+          version: ['>= 2.0.2', '< 4.0.0']
           reason: 'part of the default toolset install'
         - gem: mocha
           version: ['>= 1.0.0', '< 1.2.0']


### PR DESCRIPTION
The 3.0.0 release dropped rubies before 2.1, which is irrelevant to the puppet-module-gems