### PR TITLE
Pin down pathspec on older ruby versions; release prep for v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Ensure that only compatible pathspec versions are considered on older ruby versions
+
 ## 1.0.1
 
 - Relax `puppet_litmus` dependency range from ~> 0.21.0 to ~> 0.21

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
     * [Setup requirements](#setup-requirements)
 3. [Usage - Configuration options and additional functionality](#usage)
 4. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
-5. [Limitations - OS compatibility, etc.](#limitations)
-6. [Support](#support)
+5. [Release Process](#release-process)
+6. [Limitations - OS compatibility, etc.](#limitations)
+7. [Support](#support)
 
 ## Description
 

--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -88,10 +88,16 @@ dependencies:
         - gem: parallel
           version: '< 1.20'
           reason: 'part of the default toolset install, 1.20 requires ruby 2.5 or later'
+        - gem: pathspec
+          version: '< 1.0.0'
+          reason: 'pulled in by puppetlabs_spec_helper, 1.0.0 requires ruby 2.6 or later'
       r2.5:
         - gem: simplecov
           version: '< 0.19.0'
           reason: "0.19.0 is causing builds to hang on TravisCI"
+        - gem: pathspec
+          version: '< 1.0.0'
+          reason: 'pulled in by puppetlabs_spec_helper, 1.0.0 requires ruby 2.6 or later'
       r2.6:
         - gem: simplecov
           version: '< 0.19.0'

--- a/config/info.yml
+++ b/config/info.yml
@@ -5,4 +5,4 @@ info:
   homepage: 'https://github.com/puppetlabs/puppet-module-gems'
   licenses: 'Apache-2.0'
   summary: 'A set of gems declaring Puppet module dependencies.'
-  version: '1.0.1'
+  version: '1.0.2'


### PR DESCRIPTION
This fixes https://github.com/puppetlabs/puppetlabs_spec_helper/pull/328#issuecomment-762320608 