### PR TITLE
(maint) Fix pry dependency issue.

### DIFF
--- a/config/dependencies.yml
+++ b/config/dependencies.yml
@@ -30,7 +30,7 @@ dependencies:
           version: ['~> 3.4']
           reason: 'part of the default toolset install'
         - gem: pry
-          version: '~> 0.10.4'
+          version: '~> 0.10'
           reason: 'part of the default toolset install'
         - gem: puppet-lint
           version: ['>= 2.3.0', '< 3.0.0']


### PR DESCRIPTION
While working on bumping the agent core modules pdk template version to
2.2.0, I noticed that when trying to use a newer beaker version I would
get the following error:
```
Bundler could not find compatible versions for gem "pry":
  In Gemfile:
    beaker (~> 4.29) was resolved to 4.30.0, which depends on
      pry-byebug (~> 3.9) was resolved to 3.9.0, which depends on
        pry (~> 0.13.0)

    puppet-module-posix-dev-r2.7 (~> 1.0) was resolved to 1.1.0, which depends on
      pry (~> 0.10.4)

pdk (FATAL): Unable to resolve default Gemfile dependencies.
```
This commit removes the .z form the pry dependency so the optimistic
search isn't constrained to `0.10.4`